### PR TITLE
Using other dot notation for action reference in workflow.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Versioning
         id: versioning
-        uses: ../actions/self
+        uses: ./../actions/self
         with:
           version_template: '<<VERSION_STRING>>'
           create: true


### PR DESCRIPTION
ci(publish) -> changed dot notation for action reference