### PR TITLE
Reduced dependabot commit message prefix to less than 15 characters.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,4 @@ updates:
       - dependencies
       - npm
     commit-message:
-      prefix: dependencies -> updated dependencies
+      prefix: dependencies ->


### PR DESCRIPTION
ci(publish) -> reduced dependabot commit message to comply